### PR TITLE
show shipping info form for guests or registered

### DIFF
--- a/client/components/cart/CheckoutForm.js
+++ b/client/components/cart/CheckoutForm.js
@@ -51,9 +51,9 @@ class CheckoutForm extends React.Component {
   }
 
   render() {
-    if (Object.keys(this.props.user).length < 1) {
-      return <div>User not logged in...</div>
-    }
+    // if (Object.keys(this.props.user).length < 1) {
+    //   return <div>User not logged in...</div>
+    // }
 
     return (
       <React.Fragment>


### PR DESCRIPTION
this PR fixes the bug where the shipping form does not show up when you are a guest (unauthenticated)