### PR TITLE
actually fix item cart count 

### DIFF
--- a/client/history.js
+++ b/client/history.js
@@ -1,7 +1,14 @@
 import createHistory from 'history/createBrowserHistory'
 import createMemoryHistory from 'history/createMemoryHistory'
+import {checkLocalStorage} from './store'
+import store from './store'
 
 const history =
   process.env.NODE_ENV === 'test' ? createMemoryHistory() : createHistory()
+
+// Listen for changes to the current location.
+const unlisten = history.listen((location, action) => {
+  store.dispatch(checkLocalStorage())
+})
 
 export default history


### PR DESCRIPTION
I refactor the way I triggered CHECK_LOCALSTORAGE action by triggering every time the user clicks on a route. I used `history.listen()` method and changed `clint/history.js`.

A strange thing I noticed is that, for some reason, this merge https://github.com/Team-Aloha/grace-shopper/pull/129/files
did not actually merge my invocation of `this.props.checkLocalStorage()`

Anyway, I think using `history.listen()` is a better approach to trigger CHECK_LOCALSTORAGE action because it is invoked every time a user clicks on a link i.e. a new route is viewed.